### PR TITLE
fix(utils.py): make docstring with latex raw

### DIFF
--- a/src/eztao/ts/utils.py
+++ b/src/eztao/ts/utils.py
@@ -82,10 +82,10 @@ def add_season(t, lc_start=0, season_start=90, season_end=270):
 
 
 def median_clip(y, num_sigma=3):
-    """Clip time series using a three point median filter.
+    r"""Clip time series using a three point median filter.
 
     The sigma (standard deviation) for the time series is computed from the median  absolute deviation (MAD) as to reduce the effects from extreme outliers, where
-    sigma \sim 1.4826*MAD. If more than 10% of the data points are removed, the upper
+    sigma :math:`\sim` 1.4826*MAD. If more than 10% of the data points are removed, the upper
     bound will be lifted gradually until that fraction drops bellow 10%.
 
     Args:


### PR DESCRIPTION
## Issue
The docstring for `eztao.ts.utils.median_clip` currently contains an invalid string escape. When loaded with `importlib` via `pytest` (and possibly an interaction from `poetry`?), tests fail on `eztao` import. See below and https://github.com/skorch-dev/skorch/issues/999 for examples.

```python
<path-to-eztao>/eztao/ts/__init__.py:1: in <module>
    from .utils import *
E     File "<path-to-eztao>/eztao/ts/utils.py", line 85
E       """Clip time series using a three point median filter.
E       ^^^
E   SyntaxError: invalid escape sequence '\s'
```
## Fix
This PR makes the docstring raw and adds the `:math:` directive. Here is the updated, rendered docstring.
![image](https://github.com/user-attachments/assets/5870832d-4134-4e35-9b8a-3e589f752079)

